### PR TITLE
Fix missing task and application schema definitions

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,5 +1,5 @@
-from typing import Optional
-from pydantic import BaseModel
+from typing import Optional, List, Any
+from pydantic import BaseModel, Field
 
 class ImageOut(BaseModel):
     id: int
@@ -20,3 +20,26 @@ class DraftUpdate(BaseModel):
     description: Optional[str] = None
     category: Optional[str] = None
     price: Optional[float] = None
+
+
+class AppInfo(BaseModel):
+    """Metadata about an external application exposed by the API."""
+
+    key: str
+    name: str
+    endpoints: List[str] = Field(default_factory=list)
+
+
+class TaskCreate(BaseModel):
+    """Request payload for creating a background task."""
+
+    type: str
+
+
+class Run(BaseModel):
+    """Represents the status of a background task run."""
+
+    id: str
+    type: str
+    status: str
+    result: Optional[Any] = None


### PR DESCRIPTION
## Summary
- add `AppInfo` schema for application registry
- define `TaskCreate` and `Run` schemas used by task routes

## Testing
- `pytest`
- `uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`

------
https://chatgpt.com/codex/tasks/task_e_68c65cf40408832d9d0ddc4b0fe3e9b9